### PR TITLE
Add converting from specified timezone

### DIFF
--- a/src/Timezone.php
+++ b/src/Timezone.php
@@ -45,6 +45,16 @@ class Timezone
     }
 
     /**
+     * @param $date
+     * @return Carbon
+     */
+    public function convertFromTimezone($date, $timezone) : Carbon
+    {
+        return Carbon::parse($date, $timezone)->setTimezone('UTC');
+    }
+
+    
+    /**
      * @param  Carbon  $date
      * @return string
      */


### PR DESCRIPTION
Adding the ability to convert from a specified timezone when you might want to override the user's timezone (or in cases where no auth() user exists, i.e., seeders).
